### PR TITLE
Remove iconsets property default value to use value coming from iron-meta component

### DIFF
--- a/paper-icon-picker.html
+++ b/paper-icon-picker.html
@@ -170,16 +170,6 @@ Custom property | Description | Default
         },
 
         /**
-         * Meta iconsets
-         */
-        iconsets: {
-          type: Array,
-          value: function() {
-            return [];
-          }
-        },
-
-        /**
          * The number of icons to display in the picker.
          * the Material Design palette has 18 icons
          */
@@ -224,7 +214,7 @@ Custom property | Description | Default
       },
 
       attached: function() {
-        if (this.iconList.length === 0) {
+        if (this.iconList.length === 0 && this.iconsets && this.iconsets.length) {
           var iconList = [];
           this.iconsets.forEach(function(item){
             item.getIconNames().forEach(function(icon){


### PR DESCRIPTION
Hi,

Nice component but I could not make it work using iconsets (without specifying an icon-list attribute).
Also demo page is broken for that reason I assume.
https://www.webcomponents.org/element/vhr/paper-icon-picker/demo/demo/index.html

Solution:
Remove iconsets property default value to use value coming from iron-meta component as default value of function() {return [];} was applied after iron-meta filled the {{iconsets}} property.
Therefore iconsets was always empty.

Cheers,
Max